### PR TITLE
Added esp32/m5stick_cplus device

### DIFF
--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -539,6 +539,7 @@ module.exports = function(RED) {
             'esp32/m5stack_core2',
             'esp32/m5stack_fire',
             'esp32/m5stick_c',
+            'esp32/m5stick_cplus',
             'esp32/moddable_display_2',
             'esp32/moddable_two',
             'esp32/moddable_two_io',


### PR DESCRIPTION
because of PR for supporting esp32/m5stick_cplus device was merged. https://github.com/Moddable-OpenSource/moddable/pull/947