### PR TITLE
Unable to build with different moddable drives on Windows

### DIFF
--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -270,7 +270,7 @@ module.exports = function(RED) {
     if (os.platform() === "win32") {
         let testcmd = [
             `CALL "${process.env["ProgramFiles"]}\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat" > nul`,
-            `cd ${MODDABLE}\\build\\bin\\win\\debug`,
+            `cd /D ${MODDABLE}\\build\\bin\\win\\debug`,
             'dumpbin /headers xsbug.exe | findstr "machine"'
         ].join(" && ");
 


### PR DESCRIPTION
If you put Moddable in D drive in Windows environment and start Node-RED from C drive, the build script will not work.
Fix it with the cd command with the /D switch.

https://github.com/ralphwetzel/node-red-mcu-plugin/issues/21
