### PR TITLE
Allow node red version 2 or any release of 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1-post",
   "description": "Plugin to integrate Node-RED MCU Edition into the Node-RED Editor",
   "node-red": {
-    "version": ">=2.0.0 <=3.0.2",
+    "version": ">=2.0.0 <4.0.0",
     "plugins": {
       "mcu": "mcu_plugin.js"
     }


### PR DESCRIPTION
Currently only up to 3.0.2 is allowed. For me the plugin is working fine with 3.1.0 Beta 2.