### PR TITLE
Corrected support for NRF52, NodeRED3.1, and unregistered Platforms.

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -620,7 +620,10 @@ class manifest_builder {
 
     add(object, key) {
 
-        this.manifest[key] ??= {};
+        // this.manifest[key] ??= {};   // node 15+
+        if (!this.manifest[key]) {
+            this.manifest[key] = {};
+        }
 
         let slot = this.manifest[key];
         let obj = clone(object);

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1874,8 +1874,16 @@ module.exports = function(RED) {
                     //     env.SUBPLATFORM = platform[1]
                 break;
             case "nrf52":
-                    env.NRF52_SDK_PATH = ensure_env_path("NRF52_SDK_PATH", [`${HOME}/nrf5/nRF5_SDK_17.0.2_d674dde`]);
-                    break;        
+                switch (os.platform()) {
+                    case "win32":
+                        env.NRF52_SDK_PATH = ensure_env_path("NRF52_SDK_PATH", [`${HOME}/nrf5/nRF5_SDK_17.0.2_d674dde`]);
+                        break;
+                    case "linux": 
+                    case "darwin":
+                        env.NRF_SDK_DIR = ensure_env_path("NRF_SDK_DIR", [`${HOME}/nrf5/nRF5_SDK_17.0.2_d674dde`]);
+                        break;
+                    }
+                break;        
             case "sim":
                 break;
             default:

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1037,7 +1037,13 @@ module.exports = function(RED) {
             let n = RED.nodes.getNode(node.id);
             if (n) {
                 if (n.credentials) {
-                    node._mcu ??= {};
+
+                    // node._mcu ??= {};    // <= node 15+
+
+                    if (!node._mcu) {
+                        node._mcu = {};
+                    }
+
                     node._mcu["credentials"] = clone(n.credentials);
                 }
             }

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -2039,9 +2039,9 @@ module.exports = function(RED) {
                     case "de-DE":       // this is 'de' on masOS
                         runner_options['encoding'] = "latin1";
                         break;
-                    case "ja-JP":
-                        runner_options['encoding'] = "Shift_JIS";
-                        break;
+                    //case "ja-JP":
+                    //    runner_options['encoding'] = "Shift_JIS";
+                    //    break;
                     default:
                         runner_options['encoding'] = "utf8";
                 }

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1874,7 +1874,7 @@ module.exports = function(RED) {
                     //     env.SUBPLATFORM = platform[1]
                 break;
             case "nrf52":
-                    env.NRF_SDK_DIR = ensure_env_path("NRF_SDK_DIR", [`${HOME}/nrf5/nRF5_SDK_17.0.2_d674dde`]);
+                    env.NRF52_SDK_PATH = ensure_env_path("NRF52_SDK_PATH", [`${HOME}/nrf5/nRF5_SDK_17.0.2_d674dde`]);
                     break;        
             case "sim":
                 break;

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1962,8 +1962,16 @@ module.exports = function(RED) {
             /* Not tested! */
 
             case "sim":
-
+                if (os.platform() === "win32") {
+                    bcmds = [
+                        `CALL "${process.env["ProgramFiles"]}\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars${x_win}.bat"`,
+                        `@echo ${cmd}`,
+                        `${cmd}`,
+                    ]
+                }
+                else{
                 bcmds.push(`runthis ${cmd}`);
+                }
                 break;
                 
             case "esp":

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1381,11 +1381,11 @@ module.exports = function(RED) {
             
             if (n.type in type2manifest) {
                 
-                let mp = type2manifest[n.type];
+                // let mp = type2manifest[n.type];
 
-                if (mp.length > 0) {
-                    manifest.include_manifest(`$(MCUROOT)/${type2manifest[n.type]}`);
-                }
+                // if (mp.length > 0) {
+                //     manifest.include_manifest(`$(MCUROOT)/${type2manifest[n.type]}`);
+                // }
 
                 return;
             }

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -2205,7 +2205,8 @@ module.exports = function(RED) {
                     delete proxy;
                 }
 
-                proxy = new mcuProxy.proxy(proxy_port_mcu, "1" === options.debugtarget ? proxy_port_xsbug_log: proxy_port_xsbug);
+                // proxy = new mcuProxy.proxy(proxy_port_mcu, "1" === options.debugtarget ? proxy_port_xsbug_log: proxy_port_xsbug);
+                proxy = new mcuProxy.proxy(proxy_port_mcu, proxy_port_xsbug);
 
                 proxy.on("status", (id, data) => 
                     mcuRelay.status(id, data)

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -2055,9 +2055,9 @@ module.exports = function(RED) {
                     case "de-DE":       // this is 'de' on masOS
                         runner_options['encoding'] = "latin1";
                         break;
-                    //case "ja-JP":
-                    //    runner_options['encoding'] = "Shift_JIS";
-                    //    break;
+                    case "ja-JP":
+                        bcmds.unshift(`chcp 437`);
+                        break;
                     default:
                         runner_options['encoding'] = "utf8";
                 }

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1958,6 +1958,7 @@ module.exports = function(RED) {
             case "pico":
             case "gecko":
             case "qca4020":
+            case "nrf52":
             /* Not tested! */
 
             case "sim":

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -2039,6 +2039,9 @@ module.exports = function(RED) {
                     case "de-DE":       // this is 'de' on masOS
                         runner_options['encoding'] = "latin1";
                         break;
+                    case "ja-JP":
+                        runner_options['encoding'] = "Shift_JIS";
+                        break;
                     default:
                         runner_options['encoding'] = "utf8";
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ralphwetzel/node-red-mcu-plugin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Plugin to integrate Node-RED MCU Edition into the Node-RED Editor",
   "node-red": {
     "version": ">=2.0.0 <=3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ralphwetzel/node-red-mcu-plugin",
-  "version": "1.2.1-post",
+  "version": "1.3",
   "description": "Plugin to integrate Node-RED MCU Edition into the Node-RED Editor",
   "node-red": {
     "version": ">=2.0.0 <=3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ralphwetzel/node-red-mcu-plugin",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Plugin to integrate Node-RED MCU Edition into the Node-RED Editor",
   "node-red": {
     "version": ">=2.0.0 <=3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ralphwetzel/node-red-mcu-plugin",
-  "version": "1.3",
+  "version": "1.3.0",
   "description": "Plugin to integrate Node-RED MCU Edition into the Node-RED Editor",
   "node-red": {
     "version": ">=2.0.0 <=3.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.2",
   "description": "Plugin to integrate Node-RED MCU Edition into the Node-RED Editor",
   "node-red": {
-    "version": ">=2.0.0 <=3.0.2",
+    "version": ">=2.0.0",
     "plugins": {
       "mcu": "mcu_plugin.js"
     }


### PR DESCRIPTION
Hello,

This PR proposes four fixes:
- Allows you to try it even on undefined platforms.
- Supports NRF52
- It also works with NodeRED 3.1.
- When using Japanese, the characters are garbled on the console, so if it is Japanese, switch the console to English mode.

Thank you,