### PR TITLE
ccache: error: could not find configuration file and the LOCALAPPDATA environment variable is not set

### DIFF
--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1897,7 +1897,6 @@ module.exports = function(RED) {
                             `C:\\Espressif`
                         ]);
                         env.LOCALAPPDATA =  ensure_env_path("LOCALAPPDATA", [
-                            `${process.env["LOCALAPPDATA"]};`,
                             `${process.env["USERPROFILE"]}\\AppData\\Local`
                         ]);
                     } else {

--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1896,6 +1896,10 @@ module.exports = function(RED) {
                             `${process.env["USERPROFILE"]}\\.espressif`,
                             `C:\\Espressif`
                         ]);
+                        env.LOCALAPPDATA =  ensure_env_path("LOCALAPPDATA", [
+                            `${process.env["LOCALAPPDATA"]};`,
+                            `${process.env["USERPROFILE"]}\\AppData\\Local`
+                        ]);
                     } else {
                         try {
                             // This one is a bit different: Take it if defined, yet don't care if not!


### PR DESCRIPTION
hello,

Fixed an error that the environment variable "LOCALAPPDATA" was not set when running using the Node RED MCU Plugin.

The environment is Windows 11.
```
21 Dec 17:24:01 - [info] Node-RED version: v3.1.0
21 Dec 17:24:01 - [info] Node.js  version: v18.13.0
21 Dec 17:24:01 - [info] Windows_NT 10.0.22631 x64 LE
21 Dec 17:24:01 - [info] Loading palette nodes
21 Dec 17:24:02 - [info] Node-RED MCU Edition Runtime Version: #548dc37
21 Dec 17:24:02 - [info] Node-RED MCU Edition Plugin  Version: v1.4.1-beta.1
21 Dec 17:24:02 - [info] Moddable SDK Version: v4.3.4-19-g0bd542e (x86)
```

When I start the terminal normally, LOCALAPPDATA is set, but it was not set in the browser's Node-RED MCU Plugin's Console Monitor.

Thanks,