### PR TITLE
added FONTBM environment variable

### DIFF
--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -1863,6 +1863,7 @@ module.exports = function(RED) {
             "SHELL": process.env.SHELL,
             "PATH": process.env.PATH,
             "MODDABLE": MODDABLE,
+            "FONTBM": process.env.FONTBM,
             "BUILD": path.resolve(MODDABLE, "build")
         }
 


### PR DESCRIPTION
MODDABLE SDK uses fontbm tool to build font files. 
added FONTBM environment variable to fix environment issue.

```
Starting build process...
Host system check: Darwin Kernel Version 23.2.0: Wed Nov 15 21:53:34 PST 2023; root:xnu-10002.61.3~2/RELEASE_ARM64_T8103
MCU Build system check: p1.4.1-beta.1 + #a02cd43 @ m4.5.0-0-gdd55984
HOME directory check: /Users/kitazaki
Creating build environment for platform sim/moddable_two.
Working directory: /Users/kitazaki/tmp/20240320/mcu-plugin-cache/79g0nnznfq
> cd /Users/kitazaki/tmp/20240320/mcu-plugin-cache/79g0nnznfq
Creating build script file...
> /bin/bash ./build.sh
>> mcconfig -d -x localhost:5004 -m -p sim/moddable_two
### Error: $(FONTBM) environment variable not set. Is fontbm installed?
```