### PR TITLE
shell=true add

### DIFF
--- a/mcu_plugin.js
+++ b/mcu_plugin.js
@@ -2169,6 +2169,7 @@ module.exports = function(RED) {
                 env["PROCESSOR_ARCHITECTURE"] = process.env["PROCESSOR_ARCHITECTURE"];
 
                 runner_options["windowsHide"] = true;
+                runner_options["shell"] = true;
 
                 // https://stackoverflow.com/questions/46072248/node-js-how-to-detect-user-language
                 let locale = Intl.DateTimeFormat().resolvedOptions().locale;


### PR DESCRIPTION
hello.

I can no longer build when using the latest Node.js on Windows 11.

Env:
```
Node-RED version: v4.0.2
Node.js  version: v20.17.0
Windows11(Windows_NT 10.0.22635 x64 LE)
Node-RED MCU Edition Runtime Version: #c78b888
Node-RED MCU Edition Plugin  Version: v1.5.1
Moddable SDK Version: v4.9.5-5-g24e3e54 (x86)
```

This may be due to the influence of https://github.com/node-red/node-red/pull/4652. I set shell=true and it worked, so I'm making a PR.

Thank you.